### PR TITLE
Scale to cloud

### DIFF
--- a/02_preprocess_with_recipes.Rmd
+++ b/02_preprocess_with_recipes.Rmd
@@ -55,6 +55,19 @@ flight_data <-
   mutate_if(is.character, as.factor)
 ```
 
+Before moving forward, let's thin our data so we can run these analyses even with minimal (default) computational resources. By doing so we will avoid aborting our RStudio Cloud session.
+
+Let's sample 20% of the rows and assign it as our data:
+
+```{r}
+flight_data <- flight_data %>%
+  slice_sample(prop=0.2)
+
+nrow(flight_data)
+```
+
+Note that since we are using a subset of the original data set, the results you generate here will be slightly different than the *Preprocess your data with recipes* article.
+
 Check the number of delayed flights:
 
 ```{r}
@@ -62,6 +75,8 @@ flight_data %>%
   count(arr_delay) %>% 
   mutate(prop = n/sum(n))
 ```
+
+For example, the number of `late` and `on_time` flights you get here are less than the number of flights you see in the article. But proportions are very close, suggesting that our random sampling was indeed random and did not over or down-sampled a category vs the other.
 
 Take a look at data types and data points:
 
@@ -246,6 +261,8 @@ flights_pred <-
 flights_pred
 ```
 
+Note that the result you get here will be different than the online article since we only fitted the model to the subset of the actual data set.
+
 Let's look at model performance with ROC curve (`roc_curve()`) and plot by piping it to the `autoplot()`.
 
 ```{r}
@@ -261,7 +278,7 @@ flights_pred %>%
   roc_auc(truth = arr_delay, .pred_late)
 ```
 
-Not too bad! 
+Again, here we get a slightly lower ROC AUC value because we are using less data. But considering we're only using one fifth of the whole data set, a mere `0.006` decrease in ROC AUC is actually not bad!
 
 Now it's your turn to test out this workflow [*without*](https://tidymodels.github.io/workflows/reference/add_formula.html) this recipe! 
 

--- a/02_preprocess_with_recipes.Rmd
+++ b/02_preprocess_with_recipes.Rmd
@@ -226,7 +226,8 @@ flights_wflow
 ```
 
 Prepare the recipe and train the model:
-Be patient, this step will take a little time to compute.
+
+Be patient; this step will take a little time to compute.
 
 ```{r}
 flights_fit <- 

--- a/02_preprocess_with_recipes.Rmd
+++ b/02_preprocess_with_recipes.Rmd
@@ -53,7 +53,7 @@ flight_data <-
   mutate_if(is.character, as.factor)
 ```
 
-Before moving forward, let's thin our data so we can run these analyses even with minimal (default) computational resources. By doing so we will avoid aborting our RStudio Cloud session.
+Before moving forward, let's reduce the size of our data so we can run these analyses with the default computational resources on RStudio Cloud. By doing so we will avoid aborting our session.
 
 Let's sample 20% of the rows and assign it as our data:
 

--- a/02_preprocess_with_recipes.Rmd
+++ b/02_preprocess_with_recipes.Rmd
@@ -78,7 +78,7 @@ flight_data %>%
   mutate(prop = n/sum(n))
 ```
 
-For example, the number of `late` and `on_time` flights you get here are less than the number of flights you see in the article. But proportions are very close, suggesting that our random sampling was indeed random and did not over or down-sampled a category vs the other.
+For example, the number of `late` and `on_time` flights you get here are less than the number of flights you see in the article. The proportions are very close, though, suggesting that our random sampling was indeed random and did not over- or under-sample one category vs. the other.
 
 Take a look at data types and data points:
 

--- a/02_preprocess_with_recipes.Rmd
+++ b/02_preprocess_with_recipes.Rmd
@@ -63,7 +63,7 @@ Let's sample 20% of the rows and assign it as our data:
 set.seed(3)
 
 flight_data <- flight_data %>%
-  slice_sample(prop=0.2)
+  slice_sample(prop = 0.2)
 
 nrow(flight_data)
 ```

--- a/02_preprocess_with_recipes.Rmd
+++ b/02_preprocess_with_recipes.Rmd
@@ -32,8 +32,6 @@ library(skimr)           # for variable summaries
 Load and wrangle data:
 
 ```{r}
-set.seed(123)
-
 flight_data <- 
   flights %>% 
   mutate(
@@ -60,6 +58,10 @@ Before moving forward, let's thin our data so we can run these analyses even wit
 Let's sample 20% of the rows and assign it as our data:
 
 ```{r}
+# Fix the random numbers by setting the seed 
+# This enables the analysis to be reproducible when random numbers are used
+set.seed(3)
+
 flight_data <- flight_data %>%
   slice_sample(prop=0.2)
 
@@ -96,9 +98,6 @@ flight_data %>%
 Create training and test sets:
 
 ```{r}
-# Fix the random numbers by setting the seed 
-# This enables the analysis to be reproducible when random numbers are used 
-set.seed(555)
 # Put 3/4 of the data into the training set 
 data_split <- initial_split(flight_data, prop = 3/4)
 
@@ -227,6 +226,7 @@ flights_wflow
 ```
 
 Prepare the recipe and train the model:
+Be patient, this step will take a little time to compute.
 
 ```{r}
 flights_fit <- 
@@ -278,7 +278,7 @@ flights_pred %>%
   roc_auc(truth = arr_delay, .pred_late)
 ```
 
-Again, here we get a slightly lower ROC AUC value because we are using less data. But considering we're only using one fifth of the whole data set, a mere `0.006` decrease in ROC AUC is actually not bad!
+Good job!
 
 Now it's your turn to test out this workflow [*without*](https://tidymodels.github.io/workflows/reference/add_formula.html) this recipe! 
 

--- a/03_evaluate_with_resampling.Rmd
+++ b/03_evaluate_with_resampling.Rmd
@@ -167,12 +167,13 @@ rf_wf <-
 ```
 
 Now apply the workflow and fit the model with each fold:
-
+(Computation will take a bit, be patient.)
 ```{r}
 set.seed(456)
 rf_fit_rs <- 
   rf_wf %>% 
-  fit_resamples(folds)
+  fit_resamples(folds,
+                control = control_resamples(verbose = TRUE))
 
 rf_fit_rs
 ```

--- a/03_evaluate_with_resampling.Rmd
+++ b/03_evaluate_with_resampling.Rmd
@@ -167,7 +167,8 @@ rf_wf <-
 ```
 
 Now apply the workflow and fit the model with each fold:
-(Computation will take a bit, be patient.)
+
+(This computation will take a bit, so be patient.)
 ```{r}
 set.seed(456)
 rf_fit_rs <- 

--- a/04_tune_model_parameters.Rmd
+++ b/04_tune_model_parameters.Rmd
@@ -112,14 +112,16 @@ tree_wf <- workflow() %>%
 
 Finally, let's put the pieces together.
 
-Apply our workflow and tuning grid across folds.
+Apply the workflow and tuning grid across folds:
 
+(Be patient, with RStudio Cloud Basic settings, this computation may take several minutes.)
 ```{r}
 tree_res <- 
   tree_wf %>% 
   tune_grid(
     resamples = cell_folds,
-    grid = tree_grid
+    grid = tree_grid,
+    control = control_grid(verbose = TRUE)
     )
 
 tree_res

--- a/04_tune_model_parameters.Rmd
+++ b/04_tune_model_parameters.Rmd
@@ -114,7 +114,7 @@ Finally, let's put the pieces together.
 
 Apply the workflow and tuning grid across folds:
 
-(Be patient, with RStudio Cloud Basic settings, this computation may take several minutes.)
+(Be patient; with RStudio Cloud Basic settings, this computation may take several minutes.)
 ```{r}
 tree_res <- 
   tree_wf %>% 

--- a/05_case_study.Rmd
+++ b/05_case_study.Rmd
@@ -33,18 +33,23 @@ library(vip)         # for variable importance plots
 
 ## [The Hotel Bookings Data](https://www.tidymodels.org/start/case-study/#data)
 
-Let's read our hotel data into R:
+Let's read the hotel data into R and randomly select 25% of the rows in the data set to avoid long computation times later on. 
 
 ```{r}
 hotels <- 
   read_csv('https://tidymodels.org/start/case-study/hotels.csv') %>%
-  mutate_if(is.character, as.factor) 
+  mutate_if(is.character, as.factor) %>%
+  # randomly select rows
+  slice_sample(prop=0.25)
+
 
 dim(hotels)
 glimpse(hotels)
 ```
 
 Let's look at proportions of hotel stays that include children and/or babies:
+
+Note that your results will slightly differ from the original article, since you are only using 25% of the data.
 
 ```{r}
 hotels %>% 
@@ -187,6 +192,8 @@ top_models
 
 Let's pick candidate model 12 with a penalty value of `0.00137`:
 
+Note that because your are using less data, your mean ROC AUC will be slightly less than what's shown in the article.
+
 ```{r}
 lr_best <- 
   lr_res %>% 
@@ -262,26 +269,31 @@ rf_mod %>%
   parameters()  
 ```
 
-We will use a space-filling design to tune, with 25 candidate models: 
+We will use a space-filling design to tune with 12 candidate models (instead of 25 to reduce computation time).    
 
 ```{r}
 set.seed(345)
+
 rf_res <- 
   rf_workflow %>% 
   tune_grid(val_set,
-            grid = 25,
+            grid = 12,
             control = control_grid(save_pred = TRUE),
             metrics = metric_set(roc_auc))
 ```
 
-Here are our top 5 random forest models, out of the 25 candidates:
+Be patient here, computing the results will take about ~2 minutes to complete if you are using the default RStudio Cloud resources (1 GB memory, 1 CPU).
+
+Here are our top 5 random forest models, out of the 12 candidates:
+
+Note that your results will be different and your accuracy will take a small hit since you are using less data (only 25% of the whole data set) and setting up a smaller grid to tune model hyperparameters. 
 
 ```{r}
 rf_res %>% 
   show_best(metric = "roc_auc")
 ```
 
-We're already getting much better results than our penalized logistic regression!
+But we're already getting much better results than our penalized logistic regression!
 
 Let's plot the results:
 

--- a/05_case_study.Rmd
+++ b/05_case_study.Rmd
@@ -273,7 +273,7 @@ rf_mod %>%
   parameters()  
 ```
 
-We will use a space-filling design to tune with 12 candidate models (instead of 25 to reduce computation time).    
+We will use a space-filling design to tune with 12 candidate models (instead of 25, to reduce computation time).    
 
 Be patient here! Computing these results will take several minutes to complete if you are using the default RStudio Cloud resources (1 GB memory, 1 CPU).
 

--- a/05_case_study.Rmd
+++ b/05_case_study.Rmd
@@ -46,7 +46,7 @@ hotels <-
   read_csv('https://tidymodels.org/start/case-study/hotels.csv') %>%
   mutate_if(is.character, as.factor) %>%
   # randomly select rows
-  slice_sample(prop=0.30)
+  slice_sample(prop = 0.30)
 
 
 dim(hotels)

--- a/05_case_study.Rmd
+++ b/05_case_study.Rmd
@@ -196,7 +196,7 @@ top_models
 
 Let's pick candidate model 12 with a penalty value of `0.00137`:
 
-Note that because your are using less data, your mean ROC AUC will be slightly less than what's shown in the article.
+Note that because you are using less data, your mean ROC AUC will be slightly lower than what's shown in the article.
 
 ```{r}
 lr_best <- 

--- a/05_case_study.Rmd
+++ b/05_case_study.Rmd
@@ -275,7 +275,7 @@ rf_mod %>%
 
 We will use a space-filling design to tune with 12 candidate models (instead of 25 to reduce computation time).    
 
-Be patient here, computing these results will take several minutes to complete if you are using the default RStudio Cloud resources (1 GB memory, 1 CPU).
+Be patient here! Computing these results will take several minutes to complete if you are using the default RStudio Cloud resources (1 GB memory, 1 CPU).
 
 ```{r}
 set.seed(345)

--- a/05_case_study.Rmd
+++ b/05_case_study.Rmd
@@ -33,14 +33,20 @@ library(vip)         # for variable importance plots
 
 ## [The Hotel Bookings Data](https://www.tidymodels.org/start/case-study/#data)
 
-Let's read the hotel data into R and randomly select 25% of the rows in the data set to avoid long computation times later on. 
+Let's read the hotel data into R and randomly select 30% of the rows in the data set to avoid long computation times later on. 
+
+Note that your results will differ from the original article, since you are only using 30% of the data.
 
 ```{r}
+# Fix the random numbers by setting the seed 
+# This enables the analysis to be reproducible when random numbers are used
+set.seed(123)
+
 hotels <- 
   read_csv('https://tidymodels.org/start/case-study/hotels.csv') %>%
   mutate_if(is.character, as.factor) %>%
   # randomly select rows
-  slice_sample(prop=0.25)
+  slice_sample(prop=0.30)
 
 
 dim(hotels)
@@ -48,8 +54,6 @@ glimpse(hotels)
 ```
 
 Let's look at proportions of hotel stays that include children and/or babies:
-
-Note that your results will slightly differ from the original article, since you are only using 25% of the data.
 
 ```{r}
 hotels %>% 
@@ -60,9 +64,9 @@ hotels %>%
 
 ## [A first model: penalized logistic regression](https://www.tidymodels.org/start/case-study/#first-model)
 
- Recall [Evaluate your model with resampling](/start/resampling/#data-split) article for data splitting?
+Do you recall [Evaluate your model with resampling](/start/resampling/#data-split) article for data splitting?
  
- Let's reserve 25% of the stays to the test set:
+Let's reserve 25% of the `hotels` data for the test set:
  
 ```{r}
 set.seed(123)
@@ -159,7 +163,7 @@ lr_res <-
   lr_workflow %>% 
   tune_grid(val_set,
             grid = lr_reg_grid,
-            control = control_grid(save_pred = TRUE),
+            control = control_grid(save_pred = TRUE, verbose = TRUE),
             metrics = metric_set(roc_auc))
 
 lr_res
@@ -271,18 +275,17 @@ rf_mod %>%
 
 We will use a space-filling design to tune with 12 candidate models (instead of 25 to reduce computation time).    
 
+Be patient here, computing these results will take several minutes to complete if you are using the default RStudio Cloud resources (1 GB memory, 1 CPU).
+
 ```{r}
 set.seed(345)
-
 rf_res <- 
   rf_workflow %>% 
   tune_grid(val_set,
             grid = 12,
-            control = control_grid(save_pred = TRUE),
+            control = control_grid(save_pred = TRUE, verbose = TRUE),
             metrics = metric_set(roc_auc))
 ```
-
-Be patient here, computing the results will take about ~2 minutes to complete if you are using the default RStudio Cloud resources (1 GB memory, 1 CPU).
 
 Here are our top 5 random forest models, out of the 12 candidates:
 


### PR DESCRIPTION
This PR reduces example data size to avoid aborting and spend less time for computations. It also includes text to explain why these steps had to be taken.

- Article 2: Only 20% of the original data set is used.
- Article 5: Only 25% of the original data set is used and for random forest tuning grid size has ben reduced to 12. Currently tuning computation is a little over 2 mins.
